### PR TITLE
Restricting the version of phpunit to NOT allow phpunit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "data"
     ],
     "require-dev": {
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "5 || 6 || 7 || 8 || 9 || 10 || 11",
         "friendsofphp/php-cs-fixer": "*"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "data"
     ],
     "require-dev": {
-        "phpunit/phpunit": "5 || 6 || 7 || 8 || 9 || 10 || 11",
+        "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9 || ^10",
         "friendsofphp/php-cs-fixer": "*"
     },
     "license": "MIT",


### PR DESCRIPTION
# Description

With the recent release of [PhpUnit 12](https://phpunit.de/announcements/phpunit-12.html).  The support of metadata being ready from the function docblocks has been removed.  Now metadata needs to be added to tests via php annotations.

Fixes #2 

## Type of change

<!-- Please delete options that are not relevant (along with this comment :-) ). -->

* php supported version change
* Additional test coverage

# How Has This Been Tested?
There are no code changes, this is just to facilitate the CI testing on additional php versions.

# Checklist:

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes