### PR TITLE
Refactor/1.x performance

### DIFF
--- a/.github/workflows/codefix.yml
+++ b/.github/workflows/codefix.yml
@@ -12,10 +12,10 @@ jobs:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: ${{ matrix.php-versions }}
 
@@ -23,7 +23,7 @@ jobs:
         run: php -v
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda
 
       - name: Run Tests
         run: composer run-script codefix-ci

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,10 +14,10 @@ jobs:
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: ${{ matrix.php-versions }}
 
@@ -25,7 +25,7 @@ jobs:
         run: php -v
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda
 
       - name: Run UnitTests
         run: composer run-script tests

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install: up
 #
 build:
 	@echo "##### Building Production Containers #####"
-	@docker compose build php56
+	@(docker compose build php56)
 
 #
 # build and bring up the dev containers and install assets

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -35,22 +35,19 @@ final class Dot {
      */
     public static function get(array $searchArray, $searchKey, $default = null, $delimiter = self::DEFAULT_DELIMITER) {
         self::validateDelimiter($delimiter);
+
         $keys = explode($delimiter, $searchKey);
-        $key_pos = array_shift($keys);
+        $current = $searchArray;
 
-        if (array_key_exists($key_pos, $searchArray)) {
-            if (is_array($searchArray[$key_pos]) && count($keys)) {
-                return self::get($searchArray[$key_pos], implode($delimiter, $keys), $default, $delimiter);
-            } else {
-                if (count($keys)) {
-                    return $default;
-                }
-
-                return $searchArray[$key_pos];
+        foreach ($keys as $key) {
+            if (!is_array($current) || !array_key_exists($key, $current)) {
+                return $default;
             }
-        } else {
-            return $default;
+
+            $current = $current[$key];
         }
+
+        return $current;
     }
 
     /**
@@ -70,21 +67,24 @@ final class Dot {
      */
     public static function set(array &$setArray, $setKey, $value, $delimiter = self::DEFAULT_DELIMITER) {
         self::validateDelimiter($delimiter);
-        $keys = explode($delimiter, $setKey);
-        $key_pos = array_shift($keys);
 
-        if (count($keys)) {
-            if (!array_key_exists($key_pos, $setArray) || !is_array($setArray[$key_pos])) {
-                $setArray[$key_pos] = [];
+        $keys = explode($delimiter, $setKey);
+        $current = &$setArray;
+        $last = array_pop($keys);
+
+        foreach ($keys as $key) {
+            if (!isset($current[$key]) || !is_array($current[$key])) {
+                $current[$key] = array();
             }
-            self::set($setArray[$key_pos], implode($delimiter, $keys), $value, $delimiter);
-        } else {
-            $setArray[$key_pos] = $value;
+
+            $current = &$current[$key];
         }
+
+        $current[$last] = $value;
     }
 
     /**
-     * Does the array have the passed dot notation key.
+     * Does the array contain the passed dot notation key?
      *
      * @param mixed[]          $searchArray
      * @param non-empty-string $searchKey   a string representation of a nested key value delimited by '.' or the passed delimiters
@@ -98,9 +98,19 @@ final class Dot {
      */
     public static function has(array $searchArray, $searchKey, $delimiter = self::DEFAULT_DELIMITER) {
         self::validateDelimiter($delimiter);
-        $v = self::get($searchArray, $searchKey, "\0\0", $delimiter);
 
-        return "\0\0" !== $v; // if the default value is returned then the key was not found
+        $keys = explode($delimiter, $searchKey);
+        $current = $searchArray;
+
+        foreach ($keys as $key) {
+            if (!is_array($current) || !array_key_exists($key, $current)) {
+                return false;
+            }
+
+            $current = $current[$key];
+        }
+
+        return true;
     }
 
     /**
@@ -122,17 +132,21 @@ final class Dot {
      */
     public static function increment(array &$incrementArray, $incrementKey, $incrementor = 1, $default = 0, $delimiter = self::DEFAULT_DELIMITER) {
         self::validateDelimiter($delimiter);
+
         if (!is_numeric($incrementor)) {
             throw new InvalidArgumentException('The provided incrementor is not a numeric value');
         }
+
         $initial_value = self::get($incrementArray, $incrementKey, $default, $delimiter);
+
         if (!is_numeric($initial_value)) {
             throw new InvalidArgumentException("The value at the key position '{$incrementKey}' is not a numeric value");
         }
-        self::set($incrementArray, $incrementKey,
-            $initial_value + $incrementor, $delimiter);
 
-        return self::get($incrementArray, $incrementKey, null, $delimiter);
+        $result = $initial_value + $incrementor;
+        self::set($incrementArray, $incrementKey, $result, $delimiter);
+
+        return $result;
     }
 
     /**
@@ -178,9 +192,10 @@ final class Dot {
      */
     public static function append(array &$appendArray, $appendKey, $value, $delimiter = self::DEFAULT_DELIMITER) {
         self::validateDelimiter($delimiter);
-        $current = self::get($appendArray, $appendKey, [], $delimiter);
-        $current = (is_array($current)) ? $current : [$current];
-        $value = (is_array($value)) ? $value : [$value];
+        $current = self::get($appendArray, $appendKey, array(), $delimiter);
+        $current = (is_array($current)) ? $current : array($current);
+        $value = (is_array($value)) ? $value : array($value);
+
         self::set($appendArray, $appendKey, array_merge($current, $value), $delimiter);
     }
 
@@ -198,20 +213,22 @@ final class Dot {
     public static function delete(array &$deleteArray, $deleteKey, $delimiter = self::DEFAULT_DELIMITER) {
         self::validateDelimiter($delimiter);
 
-        if (!self::has($deleteArray, $deleteKey)) {
-            return;
-        }
-
         $keys = explode($delimiter, $deleteKey);
         $final = array_pop($keys);
+
         $current = &$deleteArray;
-        foreach ($keys as $_key) {
-            if (is_array($current[$_key])) {
-                $current = &$current[$_key];
+
+        foreach ($keys as $key) {
+            if (!isset($current[$key]) || !is_array($current[$key])) {
+                return;
             }
+
+            $current = &$current[$key];
         }
 
-        unset($current[$final]);
+        if (array_key_exists($final, $current)) {
+            unset($current[$final]);
+        }
     }
 
     /**
@@ -229,14 +246,9 @@ final class Dot {
      */
     public static function flatten(array $array, $delimiter = self::DEFAULT_DELIMITER, $prepend = '') {
         self::validateDelimiter($delimiter);
-        $flattened = [];
-        foreach ($array as $key => $value) {
-            if (is_array($value) && !empty($value)) {
-                $flattened = array_merge($flattened, self::flatten($value, $delimiter, $prepend.$key.$delimiter));
-            } else {
-                $flattened[$prepend.$key] = $value;
-            }
-        }
+
+        $flattened = array();
+        self::flattenRecursive($array, $flattened, $delimiter, $prepend);
 
         return $flattened;
     }
@@ -277,5 +289,27 @@ final class Dot {
      */
     private static function InvalidDelimiterException($message) {
         throw new InvalidArgumentException($message.' Delimiter is not valid');
+    }
+
+    /**
+     * Internal flatten accumulator.
+     *
+     * @param mixed[] $array
+     * @param mixed[] $result
+     * @param string $delimiter
+     * @param string $prepend
+     *
+     * @return void
+     */
+    private static function flattenRecursive(array $array, array &$result, $delimiter, $prepend) {
+        foreach ($array as $key => $value) {
+            $newKey = $prepend . $key;
+
+            if (is_array($value) && !empty($value)) {
+                self::flattenRecursive($value, $result, $delimiter, $newKey . $delimiter);
+            } else {
+                $result[$newKey] = $value;
+            }
+        }
     }
 }

--- a/src/Dot.php
+++ b/src/Dot.php
@@ -74,7 +74,7 @@ final class Dot {
 
         foreach ($keys as $key) {
             if (!isset($current[$key]) || !is_array($current[$key])) {
-                $current[$key] = array();
+                $current[$key] = [];
             }
 
             $current = &$current[$key];
@@ -192,9 +192,9 @@ final class Dot {
      */
     public static function append(array &$appendArray, $appendKey, $value, $delimiter = self::DEFAULT_DELIMITER) {
         self::validateDelimiter($delimiter);
-        $current = self::get($appendArray, $appendKey, array(), $delimiter);
-        $current = (is_array($current)) ? $current : array($current);
-        $value = (is_array($value)) ? $value : array($value);
+        $current = self::get($appendArray, $appendKey, [], $delimiter);
+        $current = (is_array($current)) ? $current : [$current];
+        $value = (is_array($value)) ? $value : [$value];
 
         self::set($appendArray, $appendKey, array_merge($current, $value), $delimiter);
     }
@@ -247,7 +247,7 @@ final class Dot {
     public static function flatten(array $array, $delimiter = self::DEFAULT_DELIMITER, $prepend = '') {
         self::validateDelimiter($delimiter);
 
-        $flattened = array();
+        $flattened = [];
         self::flattenRecursive($array, $flattened, $delimiter, $prepend);
 
         return $flattened;
@@ -296,17 +296,17 @@ final class Dot {
      *
      * @param mixed[] $array
      * @param mixed[] $result
-     * @param string $delimiter
-     * @param string $prepend
+     * @param string  $delimiter
+     * @param string  $prepend
      *
      * @return void
      */
     private static function flattenRecursive(array $array, array &$result, $delimiter, $prepend) {
         foreach ($array as $key => $value) {
-            $newKey = $prepend . $key;
+            $newKey = $prepend.$key;
 
             if (is_array($value) && !empty($value)) {
-                self::flattenRecursive($value, $result, $delimiter, $newKey . $delimiter);
+                self::flattenRecursive($value, $result, $delimiter, $newKey.$delimiter);
             } else {
                 $result[$newKey] = $value;
             }

--- a/src/DotFunctions.php
+++ b/src/DotFunctions.php
@@ -47,7 +47,7 @@ function dotSet(array &$setArray, $setKey, $value, $delimiter = Dot::DEFAULT_DEL
 }
 
 /**
- * Does the array have the passed dot notation key.
+ * Does the array contain the passed dot notation key?
  *
  * @param mixed[]          $searchArray
  * @param non-empty-string $searchKey   a string representation of a nested key value delimited by '.' or the passed delimiters

--- a/tests/DeleteTest.php
+++ b/tests/DeleteTest.php
@@ -9,6 +9,7 @@ class DeleteTest extends DotBase {
      * @test
      * @dataProvider deleteDataProvider
      *
+     * @param array  $array
      * @param        $key
      * @param        $expected
      * @param string $delimiter
@@ -20,10 +21,28 @@ class DeleteTest extends DotBase {
         $this->assertEquals($expected, $array);
     }
 
+
+    /**
+     * @test
+     * @dataProvider deleteCustomDelimiterDataProvider
+     *
+     * @param array  $array
+     * @param        $key
+     * @param        $expected
+     * @param string $delimiter
+     *
+     * @return void
+     */
+    public function dotDeleteCustomDelimiter(array $array, $key, $expected, $delimiter = '~') {
+        Dot::delete($array, $key, $delimiter);
+        $this->assertEquals($expected, $array);
+    }
+
     /**
      * @test
      * @dataProvider deleteDataProvider
      *
+     * @param array  $array
      * @param        $key
      * @param        $expected
      * @param string $delimiter
@@ -31,6 +50,22 @@ class DeleteTest extends DotBase {
      * @return void
      */
     public function dotDeleteFunction(array $array, $key, $expected, $delimiter = Dot::DEFAULT_DELIMITER) {
+        dotDelete($array, $key, $delimiter);
+        $this->assertEquals($expected, $array);
+    }
+
+    /**
+     * @test
+     * @dataProvider deleteCustomDelimiterDataProvider
+     *
+     * @param array  $array
+     * @param        $key
+     * @param        $expected
+     * @param string $delimiter
+     *
+     * @return void
+     */
+    public function dotDeleteFunctionCustomDelimiter(array $array, $key, $expected, $delimiter = '~') {
         dotDelete($array, $key, $delimiter);
         $this->assertEquals($expected, $array);
     }
@@ -45,6 +80,19 @@ class DeleteTest extends DotBase {
             'delete a value in mixed set' => [['a' => ['b' => ['c' => 'd', 'e' => 'f', 'g' => ['h' => 'i']]]], 'a.b.e', ['a' => ['b' => ['c' => 'd', 'g' => ['h' => 'i']]]]],
             'delete a array' => [['a' => ['b' => ['c' => 'd']]], 'a.b', ['a' => []]],
             'no key found' => [['a' => ['b' => ['c' => 'd']]], 'a.b.c.e', ['a' => ['b' => ['c' => 'd']]]],
+        ];
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public static function deleteCustomDelimiterDataProvider() {
+        return [
+            'delete a value' => [['a' => ['b' => ['c' => 'd']]], 'a~b~c', ['a' => ['b' => []]]],
+            'delete a value in set' => [['a' => ['b' => ['c' => 'd', 'e' => 'f']]], 'a~b~e', ['a' => ['b' => ['c' => 'd']]]],
+            'delete a value in mixed set' => [['a' => ['b' => ['c' => 'd', 'e' => 'f', 'g' => ['h' => 'i']]]], 'a~b~e', ['a' => ['b' => ['c' => 'd', 'g' => ['h' => 'i']]]]],
+            'delete a array' => [['a' => ['b' => ['c' => 'd']]], 'a~b', ['a' => []]],
+            'no key found' => [['a' => ['b' => ['c' => 'd']]], 'a~b~c~e', ['a' => ['b' => ['c' => 'd']]]],
         ];
     }
 }

--- a/tests/DeleteTest.php
+++ b/tests/DeleteTest.php
@@ -9,7 +9,6 @@ class DeleteTest extends DotBase {
      * @test
      * @dataProvider deleteDataProvider
      *
-     * @param array  $array
      * @param        $key
      * @param        $expected
      * @param string $delimiter
@@ -21,12 +20,10 @@ class DeleteTest extends DotBase {
         $this->assertEquals($expected, $array);
     }
 
-
     /**
      * @test
      * @dataProvider deleteCustomDelimiterDataProvider
      *
-     * @param array  $array
      * @param        $key
      * @param        $expected
      * @param string $delimiter
@@ -42,7 +39,6 @@ class DeleteTest extends DotBase {
      * @test
      * @dataProvider deleteDataProvider
      *
-     * @param array  $array
      * @param        $key
      * @param        $expected
      * @param string $delimiter
@@ -58,7 +54,6 @@ class DeleteTest extends DotBase {
      * @test
      * @dataProvider deleteCustomDelimiterDataProvider
      *
-     * @param array  $array
      * @param        $key
      * @param        $expected
      * @param string $delimiter


### PR DESCRIPTION
# Description

This was a performance rewrite to speed up operations.  There was 1 bug found in the `delete()` that caused the internal `has` check to not utilize a custom delimiter if present.

## Type of change

<!-- Please delete options that are not relevant (along with this comment :-) ). -->

* Bug fix (non-breaking change which fixes an issue)
* Refactor change, no change in interface

# How Has This Been Tested?

Internal testing in the development container and unit test coverage

- [x] CI Test Suite

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
